### PR TITLE
(fr) - fix statistics-studied-today

### DIFF
--- a/core/fr/statistics.ftl
+++ b/core/fr/statistics.ftl
@@ -28,7 +28,7 @@ statistics-in-time-span-years = { $amount ->
     [one] en {$amount} année
    *[other] en {$amount} années
   }
-statistics-studied-today = Étudié(s) { statistics-cards } { $unit ->
+statistics-studied-today = { statistics-cards } étudiée(s) { $unit ->
      [seconds] { statistics-in-time-span-seconds }
      [minutes] { statistics-in-time-span-minutes }
      [hours]   { statistics-in-time-span-hours }


### PR DESCRIPTION
It wasn't in the right order.
It'll now display: "12 cartes étudiée(s) en 26 secondes aujourd'hui (2.17s/carte)" instead of "Étudié(s) 12 cartes en 26 secondes (2.17s/carte)" which were incorrect.