### PR TITLE
Use spaced endashes `–` instead of hyphens for sentence breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 To add new strings, please make changes to the ftl/ folder in [the computer
-version](https://github.com/ankitects/anki), and then submit a PR there - when
+version](https://github.com/ankitects/anki), and then submit a PR there – when
 your PR is accepted, the strings will be automatically added here.
 
 More info: https://translating.ankiweb.net/anki/developers

--- a/core/templates/deck-config.ftl
+++ b/core/templates/deck-config.ftl
@@ -353,7 +353,7 @@ deck-config-desired-retention-tooltip =
     The default value of 0.9 will schedule cards so you have a 90% chance of remembering them when
     they come up for review again. If you increase this value, Anki will show cards more frequently
     to increase the chances of you remembering them. If you decrease the value, Anki will show cards
-    less frequently, and you will forget more of them. Be conservative when adjusting this - higher
+    less frequently, and you will forget more of them. Be conservative when adjusting this – higher
     values will greatly increase your workload, and lower values can be demoralizing when you forget
     a lot of material.
 deck-config-sm2-retention-tooltip =
@@ -378,7 +378,7 @@ deck-config-compute-optimal-weights-tooltip =
     and automatically generate parameters that are optimal for your memory and the content you're studying.
     If you have decks that vary wildly in difficulty, it is recommended to assign them separate presets, as
     the parameters for easy decks and hard decks will be different. There is no need to optimize your parameters
-    frequently - once every few months is sufficient.
+    frequently – once every few months is sufficient.
     
     By default, parameters will be calculated from the review history of all decks using the current preset. You can
     optionally adjust the search before calculating the parameters, if you'd like to alter which cards are used for


### PR DESCRIPTION
Hyphens should be used for compound-words and hyphenations, not sentence breaks. For sentence breaks either spaced endashes or unspaced emdashes should be used. In this pull request I implemented endashes, because they look closer to the past implementation with hyphens. It seems that the spaced endash is a UK style, while the US uses the emdashes for sentence breaks (see second link below).

I am not an experienced typhographer, but this is my experience from editing Wikipedia, see https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dash_draft. But a google search showed consistent recommendations in other style recommendations such as https://www.scribbr.com/language-rules/dashes/

I only looked at the new FSRS tooltips, didn't check all strings for wrong hyphens. Just also fixed that in the readme because I noticed it by accident there. Though honestly I don't care for hyphen-lengths in technical documentation all that much, just for proper typography in user-facing texts.

Not sure if I should to the PR here or in the main Anki repo. This is probably one of the most nitpicky Anki PR's ever.