### PR TITLE
Fix French using “reviewed cards” for “cards”

### DIFF
--- a/core/fr/statistics.ftl
+++ b/core/fr/statistics.ftl
@@ -49,8 +49,8 @@ statistics-in-time-span-years =
     }
 statistics-cards =
     { $cards ->
-        [one] { $cards } carte étudiée
-       *[other] { $cards } cartes étudiées
+        [one] { $cards } carte
+       *[other] { $cards } cartes
     }
 # a count of how many cards have been answered, eg "Total: 34 reviews"
 statistics-reviews =


### PR DESCRIPTION
`statistics-cards` / `statisticsCards` is not used in the context of reviews but for added cards and for future cards. The French translation uses “reviewed cards” while it should just “card”. This is the only language with this issue.