### PR TITLE
User-led media importation managment

### DIFF
--- a/core/templates/importing.ftl
+++ b/core/templates/importing.ftl
@@ -86,6 +86,10 @@ importing-updated = Updated
 importing-update-if-newer = If newer
 importing-update-always = Always
 importing-update-never = Never
+importing-update-medias = Update medias
+importing-update-medias-help =
+    When to update an existing media in your collection. By default, this is only done
+    if the matching imported media was more recently modified.
 importing-update-notes = Update notes
 importing-update-notes-help =
     When to update an existing note in your collection. By default, this is only done


### PR DESCRIPTION
More often than not, medias are lacking in collection.media, and those seems to be imported ONLY if the associated card is imported too. Thing is that "always" parameter skips the card like would "if newer" and "never" (to correct). But even without that, sometimes we want to keep our own card, even if newer or older, without taking one from the deck, we just want to re-import the medias because we lost them (more often than not like I've said). I've only found language variable to modify, but not the occurences in the code