### PR TITLE
Fix zh-CN/zh-TW true retention subtitle

### DIFF
--- a/core/zh-CN/statistics.ftl
+++ b/core/zh-CN/statistics.ftl
@@ -75,7 +75,7 @@ statistics-counts-separate-suspended-buried-cards = 分开统计暂停/搁置的
 ##      window is certain sizes.
 
 statistics-true-retention-title = 记忆保留率
-statistics-true-retention-subtitle = 间隔大于 1 天的卡片的通过率
+statistics-true-retention-subtitle = 间隔大于等于 1 天的卡片的通过率
 statistics-true-retention-tooltip = 若使用 FSRS，您的实际记忆保留率预计会接近目标保留率。请注意单日数据存在波动，建议查看月度数据。
 statistics-true-retention-range = 范围
 statistics-true-retention-pass = 通过

--- a/core/zh-TW/statistics.ftl
+++ b/core/zh-TW/statistics.ftl
@@ -93,7 +93,7 @@ statistics-counts-separate-suspended-buried-cards = 分開統計擱置/推遲的
 ##      window is certain sizes.
 
 statistics-true-retention-title = 留存比率
-statistics-true-retention-subtitle = 間隔大於 1 天的卡片的通過率
+statistics-true-retention-subtitle = 間隔大於等於 1 天的卡片的通過率
 statistics-true-retention-tooltip = 使用 FSRS 時，留存比率應與期望留存比率接近。單日統計資料存在雜訊，請按月為準參考。
 statistics-true-retention-range = 範圍
 statistics-true-retention-pass = 通過


### PR DESCRIPTION
Update the zh-CN and zh-TW translations of `statistics-true-retention-subtitle` to accurately reflect the source template ("interval ≥ 1 day"). 

The previous translations ("间隔大于 1 天" / "間隔大於 1 天") translated strictly to "> 1 day", which incorrectly excluded cards with exactly a 1-day interval and could mislead users. This PR corrects the wording to ensure consistency with the original English meaning and other locales.

## Context / Cross-locale comparison
- **Template:** “interval ≥ 1 day”
- **zh-CN (Old):** “间隔大于 1 天 …” (> 1 day)
- **zh-CN (New):** “间隔大于等于 1 天 …” (≥ 1 day)
- **zh-TW (Old):** “間隔大於 1 天 …” (> 1 day)
- **zh-TW (New):** “間隔大於等於 1 天 …” (≥ 1 day)
- **Japanese:** “1日以上” (≥ 1 day)
- **Spanish:** “intervalo de 1 día o más” (≥ 1 day)
- **French:** “intervalle ≥ 1 jour” (≥ 1 day)